### PR TITLE
fix: at line 892, memcpy(string, buf, sz) copies sz ... in...

### DIFF
--- a/src/libedataserver/e-data-server-util.c
+++ b/src/libedataserver/e-data-server-util.c
@@ -889,6 +889,8 @@ e_utf8_strftime (gchar *string,
 			sz = 0;
 	}
 
+	if (sz >= max)
+		sz = max - 1;
 	memcpy (string, buf, sz);
 	string[sz] = '\0';
 


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/libedataserver/e-data-server-util.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `src/libedataserver/e-data-server-util.c:892` |

**Description**: At line 892, memcpy(string, buf, sz) copies sz bytes from buf into string without verifying that sz does not exceed the allocated size of the destination buffer. If sz is derived from external input (e.g., a network response, file content, or IPC message) without prior validation, an attacker supplying oversized data can overflow the destination heap buffer. This is a C/C++ codebase with manual memory management, and this memcpy is flagged as an unsafe buffer operation in the security assessment.

## Changes
- `src/libedataserver/e-data-server-util.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
